### PR TITLE
Remove Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-cache: yarn
-node_js:
-  - v12
-before_install:
-  - mkdir -p $HOME/.ern

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Electrode Native Maven CLI Container Publisher
 
-[![Build Status][1]][2]
-[![ci][3]][4]
+[![ci][1]][2]
 
 This publisher can be used to publish Android or iOS Electrode Native Containers to a local or remote Maven repository, using the `mvn` command.
 
@@ -112,7 +111,5 @@ publisher.publish(
 })
 ```
 
-[1]: https://travis-ci.org/electrode-io/ern-container-publisher-maven-cli.svg?branch=master
-[2]: https://travis-ci.org/electrode-io/ern-container-publisher-maven-cli
-[3]: https://github.com/electrode-io/ern-container-publisher-maven-cli/workflows/ci/badge.svg
-[4]: https://github.com/electrode-io/ern-container-publisher-maven-cli/actions
+[1]: https://github.com/electrode-io/ern-container-publisher-maven-cli/workflows/ci/badge.svg
+[2]: https://github.com/electrode-io/ern-container-publisher-maven-cli/actions


### PR DESCRIPTION
GitHub Actions is running the same tests **much** faster (up to 50%). We don't need duplicate CI.

Also, GitHub Actions is testing with _both_ v10 and v12 or Node, while Travis was only using v12.